### PR TITLE
[web] Integrate API with client for reset password

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -11,8 +11,8 @@ import morgan from 'morgan'
 import errorHandler from './errors/handler'
 import routes from './routes'
 
-import './providers'
 import './database'
+import './providers'
 
 const app = express()
 app.use(

--- a/packages/web/src/components/Input/index.tsx
+++ b/packages/web/src/components/Input/index.tsx
@@ -1,3 +1,4 @@
+import { useField } from '@unform/core'
 import React, {
   InputHTMLAttributes,
   useCallback,
@@ -5,8 +6,6 @@ import React, {
   useRef,
   useState
 } from 'react'
-
-import { useField } from '@unform/core'
 
 import { Wrapper, InputContainer } from './styles'
 
@@ -42,12 +41,13 @@ const Input: React.FC<InputProps> = ({ name, type, children, ...rest }) => {
   return (
     <Wrapper>
       <InputContainer
-        type={type}
+        hidden={type === 'hidden'}
         isFilled={isFilled}
         isFocused={isFocused}
         hasError={!!error}
       >
         <input
+          type={type}
           ref={inputRef}
           defaultValue={defaultValue}
           onBlur={handleInputBlur}

--- a/packages/web/src/components/Input/styles.ts
+++ b/packages/web/src/components/Input/styles.ts
@@ -4,7 +4,7 @@ interface InputProps {
   isFocused: boolean
   isFilled: boolean
   hasError: boolean
-  type: string
+  hidden: boolean
 }
 
 export const Wrapper = styled.div`
@@ -31,7 +31,7 @@ export const InputContainer = styled.div<InputProps>`
   color: #5c8599;
 
   ${props =>
-    props.type === 'hidden' &&
+    props.hidden &&
     css`
       display: none;
     `}

--- a/packages/web/src/components/PasswordInput/index.tsx
+++ b/packages/web/src/components/PasswordInput/index.tsx
@@ -1,6 +1,5 @@
-import React, { InputHTMLAttributes, useState } from 'react'
-
 import Input from '@/components/Input'
+import React, { InputHTMLAttributes, useState } from 'react'
 import { FiEye, FiEyeOff } from 'react-icons/fi'
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {


### PR DESCRIPTION
Update Reset Password page to perform password reset calling the api and evaluating the result. If successful, redirect to signin page and add a success toast. If failing due to an invalid/used token, clear form and add error toast.

getInitialProps checks whether token property is sent in query string. If missing, user is redirected to forgot password page 
(should redirect to signin or home page?)